### PR TITLE
Add all current OSS products

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,95 @@
-# open-source-directory
-A public listing of all the open source software published by Springer Nature.
+# Welcome to the Springer Nature open source directory
+
+This is a public listing of all the open source software published by Springer Nature. 
+
+## Continous integration and continuous delivery tools
+
+[Halfpipe CLI](https://github.com/springernature/halfpipe)  
+A CLI for interacting with [Halfpipe](https://docs.halfpipe.io/). 
+
+## Documentation
+
+[Front-end Playbook](https://github.com/springernature/frontend-playbook)  
+The Springer Nature Front-End Playbook details how we make our web and mobile products.  
+
+## Feature flagging
+
+[Bandiera](https://github.com/springernature/bandiera)  
+[Bandiera client - Ruby](https://github.com/springernature/bandiera-client-ruby)  
+[Bandiera client - Node](https://github.com/springernature/bandiera-client-node)  
+[Bandiera client - PHP](https://github.com/springernature/bandiera-client-php)  
+Bandiera is a simple, stand-alone feature flagging service over a REST API that is not tied to any existing web framework or language.
+
+## Front-end tools
+
+[Shunter](https://github.com/springernature/shunter)  
+Shunter is a Node.js application built to read JSON and translate it into HTML. It helps you create a loosely-coupled front end which can serve traffic from one or more back end applications.
+
+[Front-end global toolkit](https://github.com/springernature/frontend-global-toolkit)  
+Springer Nature's shared front-end component packages, published via NPM.
+
+## Image manipulation
+
+[Immagine](https://github.com/springernature/immagine)
+Immagine is the image manipulation service for [nature.com](https://www.nature.com).
+
+## Linters
+[Springer Nature ESLint config](https://github.com/springernature/eslint-config-springernature)  
+The ESLint shareable config used at Springer Nature.
+
+[Dustmite](https://github.com/springernature/dustmite)  
+Dustmite is a linter for [DustJS](https://github.com/linkedin/dustjs). It checks the syntax of your dust templates and then validates them against a configurable and extensible set of rules.
+
+## Open data
+
+[Scigraph](https://github.com/springernature/scigraph)  
+SciGraph is the Springer Nature linked data platform that collates information from across the research landscape, i.e. the things, documents, people, places and relations of importance to the science and scholarly domain. See the project homepage https://www.springernature.com/scigraph for more information.
+
+## Proxies and routers
+
+[Thundermole](https://github.com/springernature/thundermole)  
+Proxy or redirect requests to different applications based on an API response. Read about [how we use Thundermole](http://cruft.io/posts/complex-routing-logic-with-thundermole/).
+
+## Web frameworks
+
+[Samatra](https://github.com/springernature/samatra)  
+[Samatra extras](https://github.com/springernature/samatra-extras)  
+[Samatra testing](https://github.com/springernature/samatra-testing)  
+[Samatra project template](https://github.com/springernature/samatra.g8)  
+Minimal web framework in the spirit of [Scalatra](http://www.scalatra.org). 
+
+## Web performance tools
+
+[Boomcatch](https://github.com/springernature/boomcatch)  
+A standalone, node.js-based beacon receiver for [boomerang](https://github.com/lognormal/boomerang). Read about [how we use Boomcatch](http://cruft.io/posts/introducing-boomcatch/).
+
+[Webpagetest mapper](https://github.com/springernature/webpagetest-mapper)  
+Maps JSON result data from [marcelduran/webpagetest-api](https://github.com/marcelduran/webpagetest-api) into human-readable document formats. Read more about [how we use Webpagetest mapper](http://cruft.io/posts/introducing-webpagetest-mapper/).
+
+## XML manipulation
+
+[vtdxml4s](https://github.com/springernature/vtdxml4s)  
+A drop in replacement for scala-xml with improved performance. It uses [VtdXml](http://vtd-xml.sourceforge.net/) to parse and query XML.
+
+## Misc
+
+### Node
+
+[Truffler](https://github.com/springernature/truffler)  
+Access web pages programmatically with [PhantomJS](http://phantomjs.org/), for running tests or scraping information.
+
+[QS middleware](https://github.com/springernature/qs-middleware)  
+Connect querystring middleware.
+
+[hasbin](https://github.com/springernature/hasbin)  
+Check whether a binary exists in the PATH environment variable.
+
+### PHP
+
+[Behat Zend Framework extension](https://github.com/springernature/zf-behat-extension)  
+A [Behat](http://behat.org/en/latest/) extension that integrates the ZendFramework client, similar to the Symfony integration.
+
+### Ruby
+
+[Macmillan Utils](https://github.com/springernature/macmillan-utils)  
+A collection of useful patterns we use in our Ruby applications.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Springer Nature's shared front-end component packages, published via NPM.
 Immagine is the image manipulation service for [nature.com](https://www.nature.com).
 
 ## Linters
+
 [Springer Nature ESLint config](https://github.com/springernature/eslint-config-springernature)  
 The ESLint shareable config used at Springer Nature.
 


### PR DESCRIPTION
Almost everything that's currently open-sourced should be in this list. I still have one or two authors to chase. 

I've added the one-line description of each product taken from each of their READMEs, and grouped them into broad categories. 